### PR TITLE
speed up builds by using rocker/verse as per #179

### DIFF
--- a/actions/build/Dockerfile
+++ b/actions/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhub/debian-gcc-release:latest
+FROM rocker/verse:latest
 # github actions recommends debian, and this is the one closest to cran https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/
 
 LABEL "maintainer"="Maximilian Held <info@maxheld.de>"
@@ -7,6 +7,7 @@ LABEL "homepage"="http://github.com/r-lib/ghactions"
 
 LABEL "com.github.actions.name"="Build R Packages"
 LABEL "com.github.actions.description"="Build Packages for rstats."
+
 LABEL "com.github.actions.icon"="package"
 LABEL "com.github.actions.color"="blue"
 

--- a/actions/check/Dockerfile
+++ b/actions/check/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhub/debian-gcc-release
+FROM rocker/verse
 # github actions recommends debian, and this is the one closest to cran https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/
 
 LABEL "maintainer"="Maximilian Held <info@maxheld.de>"

--- a/actions/covr/Dockerfile
+++ b/actions/covr/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhub/debian-gcc-release
+FROM rocker/verse
 # github actions recommends debian, and this is the one closest to cran https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/
 
 LABEL "maintainer"="Maximilian Held <info@maxheld.de>"

--- a/actions/install-deps/Dockerfile
+++ b/actions/install-deps/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhub/debian-gcc-release:latest
+FROM rocker/verse:latest
 # github actions recommends debian, and this is the one closest to cran https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/
 
 LABEL "maintainer"="Maximilian Held <info@maxheld.de>"

--- a/actions/install/Dockerfile
+++ b/actions/install/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhub/debian-gcc-release
+FROM rocker/verse
 # github actions recommends debian, and this is the one closest to cran https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/
 
 LABEL "maintainer"="Maximilian Held <info@maxheld.de>"

--- a/actions/pkgdown/Dockerfile
+++ b/actions/pkgdown/Dockerfile
@@ -1,4 +1,4 @@
-FROM rhub/debian-gcc-release
+FROM rocker/verse
 # github actions recommends debian, and this is the one closest to cran https://developer.github.com/actions/creating-github-actions/creating-a-docker-container/
 
 LABEL "maintainer"="Maximilian Held <info@maxheld.de>"


### PR DESCRIPTION
this fails, because something in rocker/verse apparently makes our `R_LIBS_USER` env var ineffective; it still exists in the containers, but libraries are installed elsewhere.
might be this https://github.com/rocker-org/rocker-versioned/blob/08ca130eaf2f517452b4d4fa65ac34842eaaafd0/r-ver/3.5.3/Dockerfile#L111-L112
can't figure this out and hacking around in our otherwise working setup seems unwise