### PR TITLE
WIP docker push all actions closes #141

### DIFF
--- a/actions/install-deps/Dockerfile
+++ b/actions/install-deps/Dockerfile
@@ -1,18 +1,1 @@
-FROM maxheld83/ghactions
-
-LABEL "com.github.actions.name"="Install R Package Dependencies"
-LABEL "com.github.actions.description"="Install Package Dependencies for rstats."
-LABEL "com.github.actions.icon"="arrow-down-circle"
-LABEL "com.github.actions.color"="blue"
-
-RUN apt-get install -y --no-install-recommends libssl-dev
-
-ENV R_LIBS="$R_LIBS_ACTION"
-# curl and git2r speed up pkg installation as per docs https://remotes.r-lib.org/index.html
-RUN Rscript -e "install.packages(c('remotes', 'curl', 'git2r', 'pkgbuild'))"
-
-# now set R_LIBS to persistent folder
-ENV R_LIBS="$R_LIBS_WORKFLOW"
-
-COPY entrypoint.R /entrypoint.R
-ENTRYPOINT ["/entrypoint.R"]
+FROM maxheld83/ghactions-install-deps


### PR DESCRIPTION
Here's a test:

*before* publishing on docker hub, the `install-deps` action took: 3:35, 3:43, 3:44, 3:52, 3:43 to complete, even though there was nothing for `remotes::install_deps()` to do, because all dependencies were cached.

My hypothesis is that this took so long, because relatively expensive `Rscript -e "install_packages('remotes')"` etc. layers had to be rebuild by the github actions runner.
(This appears not to be necessary when run inside `act` locally).

So we've now pushed `install_deps` to docker hub and are testing how fast the action is now.
`install_deps` (the action) published on docker hub now takes 2:12, 2:20, so that shaves off about 1min.
We might expect this for all the R action images, so that would shave off in sum, another 5 minutes or so.

That'd bring the total build time for a relatively simple package such as this to around ~2-4 minutes, which would be nice.